### PR TITLE
FIX order payment not created when invoices are disabled (replace #38105)

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -382,10 +382,38 @@ class OrderHistoryCore extends ObjectModel
                 $payment_method = Module::getInstanceByName($order->module);
             }
 
-            $invoices = $order->getInvoicesCollection();
-            foreach ($invoices as $invoice) {
-                /** @var OrderInvoice $invoice */
-                $rest_paid = $invoice->getRestPaid();
+            // Are invoices managed by Prestashop?
+            if (true === (bool) Configuration::get('PS_INVOICE')) {
+                $invoices = $order->getInvoicesCollection();
+                foreach ($invoices as $invoice) {
+                    /** @var OrderInvoice $invoice */
+                    $rest_paid = $invoice->getRestPaid();
+                    if ($rest_paid > 0) {
+                        $payment = new OrderPayment();
+                        $payment->order_reference = Tools::substr($order->reference, 0, 9);
+                        $payment->id_currency = $order->id_currency;
+                        $payment->amount = $rest_paid;
+                        $payment->payment_method = isset($payment_method) && $payment_method instanceof Module ? $payment_method->displayName : null;
+                        $payment->conversion_rate = $order->conversion_rate;
+                        $payment->save();
+
+                        // Update total_paid_real value for backward compatibility reasons
+                        $order->total_paid_real += $rest_paid;
+                        $order->save();
+
+                        Db::getInstance()->insert(
+                            'order_invoice_payment',
+                            [
+                                'id_order_invoice' => (int) $invoice->id,
+                                'id_order_payment' => (int) $payment->id,
+                                'id_order' => (int) $order->id,
+                            ]
+                        );
+                    }
+                }
+            } else {
+                // Disabled invoices? Then deduce $rest_paid from order payments, if any
+                $rest_paid = $order->total_paid - $order->getTotalPaid();
                 if ($rest_paid > 0) {
                     $payment = new OrderPayment();
                     $payment->order_reference = Tools::substr($order->reference, 0, 9);
@@ -402,7 +430,7 @@ class OrderHistoryCore extends ObjectModel
                     Db::getInstance()->insert(
                         'order_invoice_payment',
                         [
-                            'id_order_invoice' => (int) $invoice->id,
+                            'id_order_invoice' => 0,
                             'id_order_payment' => (int) $payment->id,
                             'id_order' => (int) $order->id,
                         ]

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -378,9 +378,6 @@ class OrderHistoryCore extends ObjectModel
 
         // set orders as paid
         if ($new_os->paid == 1) {
-            if ($order->total_paid != 0) {
-                $payment_method = Module::getInstanceByName($order->module);
-            }
 
             // Are invoices managed by Prestashop?
             if (true === (bool) Configuration::get('PS_INVOICE')) {
@@ -607,21 +604,30 @@ class OrderHistoryCore extends ObjectModel
     /**
      * Creates a payment for an order and optionally associates it with an invoice.
      *
-     * @param Order $order The order object associated with the payment.
+     * @param OrderCore $order The order object associated with the payment.
      * @param float $restPaid The remaining amount to be paid.
      * @param int $invoiceId The ID of the invoice to associate the payment with.
      *
      * @return void
      */
-    protected function createOrderPayment(Order $order, float $restPaid, int $invoiceId = 0): void {
+    protected function createOrderPayment($order, float $restPaid, int $invoiceId = 0): void {
         if ($restPaid <= 0) {
             return;
         }
+
+        $displayName = null;
+        if ($order->total_paid != 0) {
+            $payment_method = Module::getInstanceByName($order->module);
+            if ($payment_method instanceof Module) {
+                $displayName = $payment_method->displayName;
+            }
+        }
+
         $payment = new OrderPayment();
         $payment->order_reference = Tools::substr($order->reference, 0, 9);
         $payment->id_currency = $order->id_currency;
         $payment->amount = $restPaid;
-        $payment->payment_method = isset($payment_method) && $payment_method instanceof Module ? $payment_method->displayName : null;
+        $payment->payment_method = $displayName;
         $payment->conversion_rate = $order->conversion_rate;
         $payment->save();
 

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -388,54 +388,12 @@ class OrderHistoryCore extends ObjectModel
                 foreach ($invoices as $invoice) {
                     /** @var OrderInvoice $invoice */
                     $rest_paid = $invoice->getRestPaid();
-                    if ($rest_paid > 0) {
-                        $payment = new OrderPayment();
-                        $payment->order_reference = Tools::substr($order->reference, 0, 9);
-                        $payment->id_currency = $order->id_currency;
-                        $payment->amount = $rest_paid;
-                        $payment->payment_method = isset($payment_method) && $payment_method instanceof Module ? $payment_method->displayName : null;
-                        $payment->conversion_rate = $order->conversion_rate;
-                        $payment->save();
-
-                        // Update total_paid_real value for backward compatibility reasons
-                        $order->total_paid_real += $rest_paid;
-                        $order->save();
-
-                        Db::getInstance()->insert(
-                            'order_invoice_payment',
-                            [
-                                'id_order_invoice' => (int) $invoice->id,
-                                'id_order_payment' => (int) $payment->id,
-                                'id_order' => (int) $order->id,
-                            ]
-                        );
-                    }
+                    $this->createOrderPayment($order, $rest_paid, (int) $invoice->id);
                 }
             } else {
                 // Disabled invoices? Then deduce $rest_paid from order payments, if any
                 $rest_paid = $order->total_paid - $order->getTotalPaid();
-                if ($rest_paid > 0) {
-                    $payment = new OrderPayment();
-                    $payment->order_reference = Tools::substr($order->reference, 0, 9);
-                    $payment->id_currency = $order->id_currency;
-                    $payment->amount = $rest_paid;
-                    $payment->payment_method = isset($payment_method) && $payment_method instanceof Module ? $payment_method->displayName : null;
-                    $payment->conversion_rate = $order->conversion_rate;
-                    $payment->save();
-
-                    // Update total_paid_real value for backward compatibility reasons
-                    $order->total_paid_real += $rest_paid;
-                    $order->save();
-
-                    Db::getInstance()->insert(
-                        'order_invoice_payment',
-                        [
-                            'id_order_invoice' => 0,
-                            'id_order_payment' => (int) $payment->id,
-                            'id_order' => (int) $order->id,
-                        ]
-                    );
-                }
+                $this->createOrderPayment($order, $rest_paid);
             }
         }
 
@@ -643,5 +601,41 @@ class OrderHistoryCore extends ObjectModel
         } else {
             return $this->add();
         }
+    }
+
+
+    /**
+     * Creates a payment for an order and optionally associates it with an invoice.
+     *
+     * @param Order $order The order object associated with the payment.
+     * @param float $restPaid The remaining amount to be paid.
+     * @param int $invoiceId The ID of the invoice to associate the payment with.
+     *
+     * @return void
+     */
+    protected function createOrderPayment(Order $order, float $restPaid, int $invoiceId = 0): void {
+        if ($restPaid <= 0) {
+            return;
+        }
+        $payment = new OrderPayment();
+        $payment->order_reference = Tools::substr($order->reference, 0, 9);
+        $payment->id_currency = $order->id_currency;
+        $payment->amount = $restPaid;
+        $payment->payment_method = isset($payment_method) && $payment_method instanceof Module ? $payment_method->displayName : null;
+        $payment->conversion_rate = $order->conversion_rate;
+        $payment->save();
+
+        // Update total_paid_real value for backward compatibility reasons
+        $order->total_paid_real += $restPaid;
+        $order->save();
+
+        Db::getInstance()->insert(
+            'order_invoice_payment',
+            [
+                'id_order_invoice' => (int) $invoiceId,
+                'id_order_payment' => (int) $payment->id,
+                'id_order' => (int) $order->id,
+            ]
+        );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop, 9.x, 8.2
| Description?      | When invoice management is disabled, orders placed with an accepted payment status do not have an associated payment.<br/>Disabling invoices means delegating the invoicing process to a third-party system (such as an ERP or another solution), which will generate the invoices.<br/>However, since these orders are not marked as "paid," the ERP may ignore them, potentially blocking the entire process (preventing manufacturing or shipping from being initiated).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue https://github.com/PrestaShop/PrestaShop/issues/38103
| UI Tests          | 
| Fixed issue or discussion?     | Fixes [#{38103}](https://github.com/PrestaShop/PrestaShop/issues/38103)
| Related PRs       |
| Sponsor company   | KIWIK
